### PR TITLE
Show a more meaningful message when a test that uses TestExpecation fails

### DIFF
--- a/src/main/java/io/vlingo/xoom/codegen/TextExpectation.java
+++ b/src/main/java/io/vlingo/xoom/codegen/TextExpectation.java
@@ -26,13 +26,16 @@ public class TextExpectation {
     this.dialect = dialect;
   }
 
-  public String read(final String textFileName) throws IOException {
+  public String read(final String textFileName) {
     final String path =
             String.format("/text-expectations/%s/%s.text",
                     dialect.name().toLowerCase(), textFileName);
 
-    final InputStream stream = TextExpectation.class.getResourceAsStream(path);
-
-    return IOUtils.toString(stream, StandardCharsets.UTF_8.name());
+    try {
+      final InputStream stream = TextExpectation.class.getResourceAsStream(path);
+      return IOUtils.toString(stream, StandardCharsets.UTF_8.name());
+    } catch (Exception cause) {
+      throw new RuntimeException(String.format("Failed to load text expectations from `%s`.", path), cause);
+    }
   }
 }


### PR DESCRIPTION
Instead of NullPointer exception the failing test will now display:

```
java.lang.RuntimeException: Failed to load text expectations from `/text-expectations/java/basisc.text`.

  at io.vlingo.xoom.codegen.TextExpectation.read(TextExpectation.java:38)
  at io.vlingo.xoom.schemata.codegen.specs.JavaCodeGenTests.assertMatchesSpec(JavaCodeGenTests.java:45)
  at io.vlingo.xoom.schemata.codegen.specs.JavaCodeGenTests.testThatGeneratesABasicType(JavaCodeGenTests.java:41)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:564)
  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
  at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
  at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
  at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
  at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
  at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
  at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
  at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
  at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
  at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
  at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
  at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
  at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
  at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
  at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
  at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
  at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
  at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
  at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
  at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:221)
  at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.lang.NullPointerException
  at java.base/java.io.Reader.<init>(Reader.java:167)
  at java.base/java.io.InputStreamReader.<init>(InputStreamReader.java:109)
  at org.apache.commons.io.IOUtils.copy(IOUtils.java:892)
  at org.apache.commons.io.IOUtils.toString(IOUtils.java:2650)
  at org.apache.commons.io.IOUtils.toString(IOUtils.java:2676)
  at io.vlingo.xoom.codegen.TextExpectation.read(TextExpectation.java:36)
  ... 29 more
```